### PR TITLE
Add synthetic protection demo pipeline and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help start stop status restart build-parts build-equivalences ingest query health version search parts-search smoke smoke-postdeploy media-worker install-agent uninstall-agent logs-tail logs-init logs-test-db export-csv export-xlsx test daily-report pia-report pia-augment pia-baselines hase-ingest hase-synth hase-build hase-train hase-train-baseline
+.PHONY: help start stop status restart build-parts build-equivalences ingest query health version search parts-search smoke smoke-postdeploy media-worker install-agent uninstall-agent logs-tail logs-init logs-test-db export-csv export-xlsx test daily-report pia-report pia-augment pia-baselines hase-ingest hase-synth hase-build hase-train hase-train-baseline demo-proteccion
 
 ORIG_PYTHONPATH := $(value PYTHONPATH)
 export PYTHONPATH := $(CURDIR)/agents:$(CURDIR)/app$(if $(strip $(ORIG_PYTHONPATH)),:$(strip $(ORIG_PYTHONPATH)))
@@ -33,6 +33,7 @@ help:
 	@echo "  pia-report [ARGS=...]        - Emite resumen por escenario y plaza"
 	@echo "  pia-equilibrium [ARGS=...]   - Evalúa escenarios de protección contra la TIR mínima"
 	@echo "  pia-aggregate               - Agrega outcomes PIA y emite resumen por plan"
+	@echo "  demo-proteccion [ARGS=...]  - Genera datos sintéticos y corre el smoke de protección"
 	@echo "  hase-ingest [ARGS=...]   - Consolida consumos AGS/EdomeX"
 	@echo "  hase-synth [ARGS=...]    - Crea dataset de entrenamiento con sintéticos"
 	@echo "  hase-build [ARGS=...]    - Fusiona features + labels para entrenamiento"
@@ -202,6 +203,9 @@ hase-train:
 
 hase-train-baseline:
 	python3 agents/hase/scripts/train_baseline.py $(ARGS)
+
+demo-proteccion:
+	python3 scripts/demo_proteccion.py $(ARGS)
 
 # ============ Neon exports ============
 # Requiere: export DATABASE_URL='postgresql://...'

--- a/agents/hase/src/service.py
+++ b/agents/hase/src/service.py
@@ -1,0 +1,225 @@
+"""Laboratory scoring stub for the HASE engine.
+
+This module provides a deterministic-but-transparent scorer that the PIA agent can
+use while the real-time HASE service is under construction. It combines whatever
+metrics are present in the payload with optional aggregates exported by
+``agents/hase/scripts/aggregate_pia_outcomes.py``. The goal is to remove mock
+risk scores from the agent chain while keeping the logic simple enough for lab
+validation.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+
+_AGGREGATE_CANDIDATES = (
+    ROOT_DIR / "data" / "hase" / "pia_outcomes_features.csv",
+    Path("data/hase/pia_outcomes_features.csv"),
+)
+_PORTFOLIO_CANDIDATES = (
+    ROOT_DIR / "data" / "pia" / "synthetic_driver_states.csv",
+    Path("data/pia/synthetic_driver_states.csv"),
+)
+
+
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    if value is None:
+        return float(default)
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        cleaned = str(value).strip()
+        if not cleaned:
+            return float(default)
+        return float(cleaned)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    if value is None:
+        return int(default)
+    if isinstance(value, int):
+        return value
+    try:
+        cleaned = str(value).strip()
+        if not cleaned:
+            return int(default)
+        return int(float(cleaned))
+    except (TypeError, ValueError):
+        return int(default)
+
+
+@dataclass(frozen=True)
+class HaseScore:
+    placa: str
+    risk_score: float
+    probability_default: float
+    features: Dict[str, float] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "placa": self.placa,
+            "risk_score": round(self.risk_score, 3),
+            "probability_default": round(self.probability_default, 3),
+            "features": self.features,
+            "metadata": self.metadata,
+        }
+
+
+@lru_cache(maxsize=1)
+def _load_outcomes_snapshot() -> Dict[str, Dict[str, Any]]:
+    for path in _AGGREGATE_CANDIDATES:
+        try:
+            if not path.exists():
+                continue
+            with path.open("r", encoding="utf-8") as handle:
+                reader = csv.DictReader(handle)
+                rows = {row.get("placa", "").upper(): row for row in reader if row.get("placa")}
+            if rows:
+                return rows
+        except Exception:
+            continue
+    return {}
+
+
+@lru_cache(maxsize=1)
+def _load_portfolio_snapshot() -> Dict[str, Dict[str, Any]]:
+    for path in _PORTFOLIO_CANDIDATES:
+        try:
+            if not path.exists():
+                continue
+            with path.open("r", encoding="utf-8") as handle:
+                reader = csv.DictReader(handle)
+                rows = {row.get("placa", "").upper(): row for row in reader if row.get("placa")}
+            if rows:
+                return rows
+        except Exception:
+            continue
+    return {}
+
+
+def _combine_snapshots(placa: str) -> Dict[str, Any]:
+    combined: Dict[str, Any] = {}
+    portfolio = _load_portfolio_snapshot().get(placa)
+    outcomes = _load_outcomes_snapshot().get(placa)
+    if portfolio:
+        combined.update(portfolio)
+    if outcomes:
+        combined.update({key: value for key, value in outcomes.items() if key not in combined})
+    return combined
+
+
+def _collect_features(payload: Dict[str, Any], snapshot: Optional[Dict[str, Any]]) -> Dict[str, float]:
+    coverage_30 = _coerce_float(payload.get("coverage_ratio_30d"), 0.0)
+    coverage_14 = _coerce_float(payload.get("coverage_ratio_14d"), coverage_30)
+    downtime_hours = _coerce_float(payload.get("downtime_hours_30d"), 0.0)
+    arrears_amount = _coerce_float(payload.get("arrears_amount"), 0.0)
+    expected_payment = _coerce_float(payload.get("expected_payment"), 11_000.0)
+    bank_transfer = _coerce_float(payload.get("bank_transfer"), 0.0)
+    gnv_credit = _coerce_float(payload.get("gnv_credit_30d"), 0.0)
+
+    features: Dict[str, float] = {
+        "coverage_ratio_30d": coverage_30,
+        "coverage_ratio_14d": coverage_14,
+        "downtime_hours_30d": downtime_hours,
+        "arrears_amount": arrears_amount,
+        "expected_payment": expected_payment,
+        "bank_transfer": bank_transfer,
+        "gnv_credit_30d": gnv_credit,
+    }
+
+    if snapshot:
+        numeric_keys = {
+            "protections_remaining",
+            "behaviour_tag_payment_refusal_count",
+            "downtime_hours_14d",
+            "downtime_hours_7d",
+            "coverage_ratio_7d",
+            "cash_collection",
+            "observed_payment",
+            "gnv_credit_14d",
+            "gnv_credit_7d",
+        }
+        for key in numeric_keys:
+            value = snapshot.get(key)
+            if value is None:
+                continue
+            try:
+                features[key] = float(value)
+            except (TypeError, ValueError):
+                continue
+    return features
+
+
+def _score_from_features(features: Dict[str, float]) -> float:
+    coverage_gap = max(0.0, 1.0 - min(features.get("coverage_ratio_14d", 0.0), 1.0))
+    payment_gap = max(
+        0.0,
+        features.get("expected_payment", 0.0)
+        - (features.get("bank_transfer", 0.0) + features.get("gnv_credit_30d", 0.0)),
+    )
+    arrears = max(0.0, features.get("arrears_amount", 0.0))
+    expected_payment = max(features.get("expected_payment", 1.0), 1.0)
+
+    arrears_ratio = arrears / expected_payment
+    payment_gap_ratio = payment_gap / expected_payment
+    downtime_norm = min(features.get("downtime_hours_30d", 0.0) / 120.0, 1.0)
+
+    score = (
+        0.45 * coverage_gap
+        + 0.25 * payment_gap_ratio
+        + 0.20 * downtime_norm
+        + 0.10 * min(arrears_ratio, 1.0)
+    )
+    return min(max(score, 0.0), 1.0)
+
+
+def _logistic_probability(score: float) -> float:
+    return 1.0 / (1.0 + math.exp(-((score * 6.0) - 3.0)))
+
+
+def score_payload(payload: Dict[str, Any]) -> HaseScore:
+    if not isinstance(payload, dict):
+        raise TypeError("payload must be a mapping with vehicle metrics")
+
+    placa_raw = payload.get("placa") or payload.get("plate") or "UNKNOWN"
+    placa = str(placa_raw).upper()
+
+    snapshot = _combine_snapshots(placa)
+    features = _collect_features(payload, snapshot or None)
+    risk_score = _score_from_features(features)
+    probability_default = _logistic_probability(risk_score)
+
+    metadata: Dict[str, Any] = {
+        "source": "hase_lab_stub",
+        "used_snapshot": bool(snapshot),
+    }
+    if snapshot:
+        metadata["snapshot_version"] = snapshot.get("window") or snapshot.get("_window")
+        metadata["protections_remaining"] = _coerce_int(snapshot.get("protections_remaining"), 0)
+
+    return HaseScore(
+        placa=placa,
+        risk_score=risk_score,
+        probability_default=probability_default,
+        features=features,
+        metadata=metadata,
+    )
+
+
+def score_driver(placa: str, *, payload: Optional[Dict[str, Any]] = None) -> HaseScore:
+    base = payload.copy() if isinstance(payload, dict) else {}
+    base.setdefault("placa", placa)
+    return score_payload(base)
+
+
+__all__ = ["HaseScore", "score_payload", "score_driver"]

--- a/agents/hase/tests/test_hase_service.py
+++ b/agents/hase/tests/test_hase_service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from agents.hase.src.service import score_payload
+
+ROOT = Path(__file__).resolve().parents[3]
+STATES_PATH = ROOT / "data" / "pia" / "synthetic_driver_states.csv"
+
+
+def _load_sample() -> dict[str, str]:
+    with STATES_PATH.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            return row
+    raise RuntimeError("synthetic_driver_states.csv está vacío; ejecuta pia_seed_synthetic_portfolio.py primero")
+
+
+def test_score_payload_uses_portfolio_snapshot() -> None:
+    state = _load_sample()
+    payload = {
+        "placa": state["placa"],
+        "expected_payment": float(state["expected_payment"]),
+        "coverage_ratio_30d": float(state["coverage_ratio_30d"]),
+        "coverage_ratio_14d": float(state["coverage_ratio_14d"]),
+        "downtime_hours_30d": float(state["downtime_hours_30d"]),
+        "arrears_amount": float(state["arrears_amount"]),
+        "bank_transfer": float(state["bank_transfer"]),
+        "gnv_credit_30d": float(state["gnv_credit_30d"]),
+    }
+    score = score_payload(payload)
+
+    assert score.placa == state["placa"].upper()
+    assert "protections_remaining" in score.features
+    assert score.metadata.get("used_snapshot") is True

--- a/docs/demo_runbook_hase_pia_tir_proteccion.md
+++ b/docs/demo_runbook_hase_pia_tir_proteccion.md
@@ -1,0 +1,121 @@
+# Demo Runbook — HASE / PIA / TIR / Protección
+
+Esta guía describe cómo correr el demo sintético end-to-end y cómo validar cada componente (HASE, PIA, Protección y cálculo de TIR). Al final se listan notas sobre integraciones externas opcionales (WhatsApp/Twilio/Make) para escenarios más realistas.
+
+---
+
+## 1. Preparar el entorno
+- Repositorio en `main` con los scripts actualizados.
+- Python 3.10+ y dependencias ya instaladas (`pip install -r requirements.txt`).
+- No se requieren claves externas para el flujo sintético, salvo que quieras generar alertas vía LLM (usa modo `template`).
+
+### Archivos que produce el pipeline
+| Archivo | Descripción |
+| --- | --- |
+| `data/pia/synthetic_driver_states.csv` | Cartera sintética (~200 financiamientos) con cobertura, telemetría, pagos y banderas HASE/PIA. |
+| `data/pia/pia_outcomes_log.csv` | Log detallado de decisiones PIA y escenarios de protección evaluados. |
+| `data/hase/pia_outcomes_features.csv` | Feature store para dashboards (protecciones restantes, outcomes por ventana, banderas de comportamiento). |
+| `reports/pia_plan_summary.csv` | Resumen por plan (conteos, protecciones restantes promedio/mediana, alertas). |
+| `reports/pia_llm_outbox.jsonl` (opcional) | Narrativas proactivas generadas por el notifier LLM en modo plantilla. |
+
+---
+
+## 2. Ejecutar el demo end-to-end
+
+### Opción rápida (recomendado)
+```bash
+make demo-proteccion
+```
+Esto ejecuta internamente `scripts/demo_proteccion.py`, que a su vez:
+1. Genera la cartera sintética (`pia_seed_synthetic_portfolio.py`).
+2. Corre el pipeline HASE → PIA → TIR (`pia_generate_dummy_outcomes.py --reset-log`).
+3. Muestra un monitor CLI (`pia_plan_summary_monitor.py`).
+4. Si pasas `ARGS="--llm"`, activa el notifier LLM en modo plantilla.
+
+Ejemplos:
+- Solo datos: `make demo-proteccion`
+- Demo custom: `make demo-proteccion ARGS="--size 180 --seed 99"
+- Con alertas LLM: `make demo-proteccion ARGS="--llm --llm-limit 3"`
+
+### Opción manual (paso a paso)
+```bash
+python3 scripts/pia_seed_synthetic_portfolio.py --size 200 --seed 2025
+python3 scripts/pia_generate_dummy_outcomes.py --reset-log
+python3 scripts/pia_plan_summary_monitor.py
+# opcional LLM
+PIA_LLM_MODE=template PIA_LLM_ALERTS=1 python3 scripts/pia_llm_notifier.py \
+  --limit 3 --pia-outbox reports/pia_llm_outbox.jsonl --skip-email
+```
+
+---
+
+## 3. Validar cada componente
+
+### 3.1 HASE (scoring)
+Verifica que el stub use los snapshots generados (cobertura, pagos, telemetría):
+```bash
+python3 - <<'PY'
+from agents.hase.src.service import score_payload
+payload = {
+    "placa": "LAB-022",
+    "expected_payment": 16800,
+    "coverage_ratio_30d": 0.45,
+    "coverage_ratio_14d": 0.38,
+    "downtime_hours_30d": 120,
+    "arrears_amount": 1800,
+    "bank_transfer": 6000,
+    "gnv_credit_30d": 7000,
+}
+score = score_payload(payload)
+print(score.to_dict())
+PY
+```
+> Observa que `features.protections_remaining` y el flag `used_snapshot` sean verdaderos, lo que confirma que el stub leyó `synthetic_driver_states.csv`.
+
+### 3.2 PIA (reglas, triggers y logging)
+- El script de outcomes llama internamente a `decide_action` por placa. Puedes inspeccionar un caso puntual revisando `data/pia/pia_outcomes_log.csv` o ejecutando:
+```bash
+python3 agents/pia/scripts/evaluate_protection_scenarios.py \
+  --placa LAB-022 --market edomex --balance 470000 --payment 16800 --term 44
+```
+- El monitor CLI (`pia_plan_summary_monitor.py`) reporta contratos en estado crítico (expirados, revisión manual, sin protecciones).
+
+### 3.3 Protección + TIR
+- Cada outcome registrado incluye el escenario TIR seleccionado (`viable[0]`), su `annual_irr`, `payment_change`, `capitalized_interest` y si requiere revisión manual.
+- Para inspeccionar a detalle usa `data/pia/pia_outcomes_log.csv` o filtra en `data/hase/pia_outcomes_features.csv` las columnas que terminan en `_synthetic_protection_*`.
+
+### 3.4 Dashboards
+Los CSV listados en la sección de fuentes se pueden conectar directamente a tu herramienta (Metabase, Superset, Power BI). En `docs/hus_dashboard_proteccion.md` tienes HUs quirúrgicas con los cortes sugeridos (riesgo vs cobertura, heatmaps de protección, composición de pagos, TIR drill-down, etc.).
+
+---
+
+## 4. Integraciones opcionales (WhatsApp / Twilio / Make)
+
+El demo sintético no activa canales externos, pero el pipeline deja todo listo para conectarlos:
+
+| Integración | Notas |
+| --- | --- |
+| WhatsApp Business API | Requiere Twilio/Meta + plantillas aprobadas (`PIA_OPCIONES`, `PIA_RECORDATORIO`, etc.). Se deben mapear las acciones PIA (ej. `offer_protection`) al envío de mensajes. Revisa `agents/pia/src/config.py` para nombres de plantillas. |
+| Twilio | Configura `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM` en `.env` y adapta `app/api.py` / `whatsapp.service.ts` para inyectar los mensajes generados por el demo. |
+| Make / n8n | Cuando el notifier LLM genera alertas (`pia_llm_outbox.jsonl`), se pueden consumir desde Make; agrega un webhook que lea el JSONL o escucha eventos via `app/storage.log_event('pia_alert', …)`. |
+| PWA | El `synthetic_driver_states.csv` puede hidratar stores front-end (`credit-scoring`, `risk.service`) para mostrar score HASE y banderas en el UI. También puedes mockear respuestas del backend (`/pia/protection/evaluate`) devolviendo los escenarios precomputados del log. |
+
+> Si necesitas replicar lo que hace hoy el bot de postventa (Make + WhatsApp), usa `pia_llm_notifier.py` para generar el payload base y de allí dispara el flujo en Make. Sólo tendrás que mapear `flags`, `metric_snapshot` y `content` a tus plantillas actuales.
+
+---
+
+## 5. Troubleshooting rápido
+- **Sin escenarios viables para muchas placas** → revisa `synthetic_driver_states.csv`; los escenarios `baseline` suelen no requerir protección. Ajusta `SCENARIO_WEIGHTS` o los parámetros de TIR si quieres mayor cobertura.
+- **Score HASE siempre cero** → confirma que corriste `pia_seed_synthetic_portfolio.py` y que `synthetic_driver_states.csv` existe. El stub cachea el snapshot, reinicia el intérprete si cambias el CSV.
+- **Alertas LLM vacías** → asegúrate de exportar `PIA_LLM_MODE=template` y `PIA_LLM_ALERTS=1` antes de ejecutar el notifier.
+
+---
+
+## 6. Checklist previo al demo en vivo
+- [ ] Correr `make demo-proteccion` una hora antes y validar las rutas principales.
+- [ ] Revisar el dashboard conectado a los CSV (estado > refresco). 
+- [ ] (Opcional) Activar `make demo-proteccion ARGS="--llm"` para tener narrativas frescas.
+- [ ] Confirmar que `data/pia/pia_outcomes_log.csv` y `data/hase/pia_outcomes_features.csv` tengan registros para las placas que usarás como ejemplo.
+- [ ] Si usarás un gadget externo (WhatsApp, Make), prueba el webhook con una placa y verifica que reciba la alerta generada.
+
+Listo: con este runbook puedes demostrar de punta a punta el funcionamiento sintético de HASE/PIA/TIR/Protección y tener un camino claro para habilitar los canales reales cuando estén disponibles.

--- a/docs/hus_dashboard_proteccion.md
+++ b/docs/hus_dashboard_proteccion.md
@@ -1,0 +1,36 @@
+# Dashboard Protección · HUs Quirúrgicas
+
+## Contexto
+- El demo sintético ahora se genera con `make demo-proteccion`, que encadena:
+  1. `scripts/pia_seed_synthetic_portfolio.py` — 200 financiamientos con escenarios baseline, consumption_gap, fault_alert y delinquency.
+  2. `scripts/pia_generate_dummy_outcomes.py --reset-log` — corre HASE → PIA → TIR y actualiza `data/pia/pia_outcomes_log.csv`, `data/hase/pia_outcomes_features.csv`, `reports/pia_plan_summary.csv`.
+  3. `scripts/pia_plan_summary_monitor.py` — resumen rápido en CLI.
+  4. Opcional: `scripts/pia_llm_notifier.py` en modo template (`--llm`) para generar narrativas en `reports/pia_llm_outbox.jsonl`.
+- El stub de HASE (`agents/hase/src/service.py`) consume automáticamente `data/pia/synthetic_driver_states.csv`, por lo que los scores reflejan cobertura, recaudo, fallas y protecciones reales.
+
+## Fuentes de datos disponibles
+| Archivo | Uso principal |
+| --- | --- |
+| `data/pia/synthetic_driver_states.csv` | Estado por placa (plan, balance, cobertura, pagos, banderas HASE/PIA). |
+| `data/pia/pia_outcomes_log.csv` | Decisiones PIA y escenarios TIR evaluados (log detallado). |
+| `data/hase/pia_outcomes_features.csv` | Feature store para dashboards (protecciones, outcomes por ventana, banderas). |
+| `reports/pia_plan_summary.csv` | Resumen por plan (conteos, protecciones restantes, alertas). |
+| `reports/pia_llm_outbox.jsonl` (opcional) | Narrativas LLM por placa con flags y métricas clave. |
+
+## Historias de Usuario (HUs)
+
+| ID | Rol | Necesito | Para | Criterios de aceptación |
+| --- | --- | --- | --- | --- |
+| HU-01 | Risk Manager | ver un snapshot del portafolio por plan (Total, Básica, Light, Caduca, Ilimitada) | priorizar seguimiento y dimensionar riesgo | Dashboard muestra tarjetas con: contratos activos, protecciones promedio, TIR promedio viable, % planes expirados. Datos vienen de `pia_plan_summary.csv`; se actualiza tras `make demo-proteccion`. |
+| HU-02 | Analista PIA | identificar placas con riesgo alto por cobertura o fallas | programar intervenciones proactivas | Scatter `risk_score` (Y) vs `coverage_ratio_14d` (X) usando `pia_outcomes_features.csv`. Colores por `scenario` (`synthetic_state.scenario`) y tamaño por `arrears_amount`. Tooltips incluyen `downtime_hours_30d`, `protections_remaining`. |
+| HU-03 | Operaciones Protección | monitorear salud de la protección (restantes, caducadas, manuales) | coordinar reestructuras y ventilación | Heatmap cruzando `last_plan_type` vs `protections_flag_manual`, `protections_flag_expired`, `protections_flag_negative`. Incluye listado clicable con `placa`, `protections_remaining`, `days_since_last_outcome`. |
+| HU-04 | CFO | evaluar impacto de escenarios TIR | validar que flexibilidad mantiene rentabilidad | Tabla `pia_outcomes_log.csv` filtrada a outcome `synthetic_protection`. Columnas: `placa`, `action` PIA, `scenario.type`, `annual_irr`, `payment_change`, `requires_manual_review`. Permite ordenar por TIR y exportar CSV. |
+| HU-05 | Tesorería | comparar composición de pagos (transferencia, efectivo) vs esperado | anticipar gaps de liquidez | Stack bar por plan/plaza con `bank_transfer` y `cash_collection` (desde `synthetic_driver_states.csv`). Añadir línea con `observed_payment / expected_payment`. Resalta placas con `arrears_amount > 0`. |
+| HU-06 | Customer Success | recibir alertas accionables con narrativa | contactar operadores con discurso correcto | Widget que consume `pia_llm_outbox.jsonl`: muestra fecha, `placa`, flags (`protecciones_negativas`, `plan_expirado`, etc.), texto generado. Botón descarga JSONL. Requiere habilitar `--llm` en el pipeline. |
+| HU-07 | Gestión de Estrategia | trackear eficiencia del demo | medir adopción y consistencia | Sección “Runbook” con fecha/hora del último `make demo-proteccion`, seed usado y duración de cada paso (leer `logs/demo_proteccion.log` si se agrega logging o usar timestamps de archivos). |
+
+## Pasos siguientes sugeridos
+1. Integrar `make demo-proteccion` en CI/staging con cron (ej. cada noche) para mantener datasets frescos.
+2. Configurar dashboard (Superset/Metabase/Power BI) apuntando directo a los CSV/Parquet anteriores.
+3. Habilitar exportaciones Parquet diarias (ej. `exports/demo/YYYYMMDD/*.parquet`) si se necesita histórico.
+4. Conectar el widget LLM únicamente cuando existan alertas nuevas (comparar timestamp más reciente). 

--- a/scripts/demo_proteccion.py
+++ b/scripts/demo_proteccion.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Orchestrates the synthetic protection demo end-to-end."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(cmd: Sequence[str], *, env: dict[str, str] | None = None) -> None:
+    display = " ".join(cmd)
+    print(f"→ {display}")
+    subprocess.run(cmd, check=True, cwd=ROOT, env=env)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the synthetic protection demo pipeline")
+    parser.add_argument("--size", type=int, default=200, help="Cantidad de financiamientos sintéticos a generar")
+    parser.add_argument("--seed", type=int, default=2025, help="Semilla para reproducibilidad")
+    parser.add_argument("--skip-seed", action="store_true", help="No regenerar cartera antes de la corrida")
+    parser.add_argument("--skip-monitor", action="store_true", help="Omitir el monitor CLI al final")
+    parser.add_argument("--llm", action="store_true", help="Ejecutar pia_llm_notifier en modo plantilla al finalizar")
+    parser.add_argument("--llm-limit", type=int, default=5, help="Máximo de alertas a generar si --llm está activo")
+    parser.add_argument(
+        "--llm-outbox",
+        type=Path,
+        default=ROOT / "reports" / "pia_llm_outbox.jsonl",
+        help="Archivo JSONL donde se encolan las alertas LLM",
+    )
+    return parser.parse_args()
+
+
+def run_demo(args: argparse.Namespace) -> None:
+    if not args.skip_seed:
+        _run(
+            [
+                "python3",
+                "scripts/pia_seed_synthetic_portfolio.py",
+                "--size",
+                str(args.size),
+                "--seed",
+                str(args.seed),
+            ]
+        )
+    else:
+        print("→ Omitiendo generación de cartera sintética (--skip-seed)")
+
+    _run(["python3", "scripts/pia_generate_dummy_outcomes.py", "--reset-log"])
+
+    if not args.skip_monitor:
+        _run(["python3", "scripts/pia_plan_summary_monitor.py"])
+    else:
+        print("→ Omitiendo monitor CLI (--skip-monitor)")
+
+    if args.llm:
+        env = os.environ.copy()
+        env.setdefault("PIA_LLM_MODE", "template")
+        env.setdefault("PIA_LLM_ALERTS", "1")
+        cmd = [
+            "python3",
+            "scripts/pia_llm_notifier.py",
+            "--limit",
+            str(args.llm_limit),
+            "--pia-outbox",
+            str(args.llm_outbox),
+            "--skip-email",
+        ]
+        _run(cmd, env=env)
+        print(f"Alertas guardadas en {args.llm_outbox}")
+    else:
+        print("→ Notifier LLM omitido (usa --llm para habilitarlo)")
+
+    print("\nDemo completada. Artefactos clave:")
+    print("  - data/pia/synthetic_driver_states.csv")
+    print("  - data/pia/pia_outcomes_log.csv")
+    print("  - data/hase/pia_outcomes_features.csv")
+    print("  - reports/pia_plan_summary.csv")
+
+
+def main() -> int:
+    try:
+        run_demo(parse_args())
+    except subprocess.CalledProcessError as exc:
+        print(f"Comando falló con código {exc.returncode}", file=sys.stderr)
+        return exc.returncode or 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pia_generate_dummy_outcomes.py
+++ b/scripts/pia_generate_dummy_outcomes.py
@@ -13,7 +13,7 @@ import csv
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -25,16 +25,18 @@ from agents.pia.src.outcomes import (  # noqa: E402
     aggregate_outcomes,
     load_outcomes,
 )
-from agents.pia.src.rules import PIADecision  # noqa: E402
+from agents.pia.src.rules import PIADecision, decide_action  # noqa: E402
 from agents.pia.src.tir_equilibrium_engine import (  # noqa: E402
     ProtectionContext,
     get_default_policy,
 )
 from agents.pia.src.tir_equilibrium_service import evaluate_scenarios  # noqa: E402
+from agents.hase.src.service import score_payload  # noqa: E402
 
 DEFAULT_SUMMARY_PATH = ROOT / "reports" / "pia_plan_summary.csv"
 DEFAULT_FEATURES_PATH = ROOT / "data" / "hase" / "pia_outcomes_features.csv"
-DEFAULT_CONTRACTS_PATH = ROOT / "data" / "pia" / "protection_contracts_dummy.csv"
+DEFAULT_CONTRACTS_PATH = ROOT / "data" / "pia" / "synthetic_contracts.csv"
+DEFAULT_STATES_PATH = ROOT / "data" / "pia" / "synthetic_driver_states.csv"
 
 
 @dataclass(frozen=True)
@@ -57,9 +59,9 @@ DEFAULT_PROFILE = FinancialProfile(balance=500_000, payment=18_000, term_months=
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate synthetic protection outcomes and aggregate them")
     parser.add_argument("--contracts", type=Path, default=DEFAULT_CONTRACTS_PATH, help="CSV with dummy protection contracts")
+    parser.add_argument("--states", type=Path, default=DEFAULT_STATES_PATH, help="CSV con estados y telemetría sintética")
     parser.add_argument("--log", type=Path, default=DEFAULT_LOG_PATH, help="Where to store outcome log entries")
     parser.add_argument("--market", default="edomex", help="Market assigned to generated contexts")
-    parser.add_argument("--risk-band", default="medio", help="Risk band used when logging outcomes")
     parser.add_argument("--notes", default="Synthetic lab outcome", help="Notes to attach to recorded outcomes")
     parser.add_argument("--windows", type=int, nargs="*", default=[30, 90, 180], help="Windows (days) for aggregation pivots")
     parser.add_argument("--features-out", type=Path, default=DEFAULT_FEATURES_PATH, help="Destination for aggregated features CSV")
@@ -109,6 +111,48 @@ def load_contracts(path: Path) -> List[ProtectionContract]:
     return contracts
 
 
+def load_states(path: Path) -> Dict[str, Dict[str, str]]:
+    states: Dict[str, Dict[str, str]] = {}
+    if not path.exists():
+        return states
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            placa = (row.get("placa") or "").strip().upper()
+            if not placa:
+                continue
+            states[placa] = row
+    return states
+
+
+def _to_float(value: Optional[str], default: float = 0.0) -> float:
+    if value is None or value == "":
+        return float(default)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _to_int(value: Optional[str], default: int = 0) -> int:
+    if value is None or value == "":
+        return int(default)
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def _to_bool(value: Optional[str | int | float | bool], default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return value != 0
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
 def select_financials(plan_type: str, index: int) -> FinancialProfile:
     key = plan_type.strip().lower()
     profile = FINANCIAL_PROFILES.get(key)
@@ -126,40 +170,166 @@ def iterate_contracts(path: Path) -> Iterator[Tuple[int, ProtectionContract]]:
         yield idx, contract
 
 
-def build_context(contract: ProtectionContract, profile: FinancialProfile, market: str) -> ProtectionContext:
+def build_context(
+    contract: ProtectionContract,
+    profile: FinancialProfile,
+    market: str,
+    state: Optional[Dict[str, str]],
+) -> ProtectionContext:
+    if state:
+        market_value = (state.get("market") or market).strip() or market
+        balance = _to_float(state.get("balance"), profile.balance)
+        payment = _to_float(state.get("payment"), profile.payment)
+        term_months = _to_int(state.get("term_months"), profile.term_months)
+        protections_allowed = _to_int(state.get("protections_allowed"), contract.protections_allowed)
+        protections_used = _to_int(state.get("protections_used"), contract.protections_used)
+        status = (state.get("contract_status") or contract.status or "active").strip()
+        valid_until = state.get("contract_valid_until") or contract.valid_until
+        reset_cycle_days_raw = _to_int(state.get("contract_reset_cycle_days"), contract.reset_cycle_days or 0)
+        reset_cycle_days = reset_cycle_days_raw or None
+        requires_manual = _to_bool(state.get("requires_manual_review"), contract.requires_manual_review)
+        has_consumption_gap = bool(_to_int(state.get("hase_consumption_gap_flag"), 0))
+        has_fault_alert = bool(_to_int(state.get("hase_fault_alert_flag"), 0))
+        telemetry_ok = bool(_to_int(state.get("hase_telemetry_ok_flag"), 1))
+        scenario_label = (state.get("scenario") or "").strip().lower()
+        has_recent_promise = bool(_to_int(state.get("has_recent_promise_break"), 0))
+        has_delinquency = status.lower() == "expired" or scenario_label == "delinquency"
+    else:
+        market_value = market
+        balance = profile.balance
+        payment = profile.payment
+        term_months = profile.term_months
+        protections_allowed = contract.protections_allowed
+        protections_used = contract.protections_used
+        status = contract.status
+        valid_until = contract.valid_until
+        reset_cycle_days = contract.reset_cycle_days
+        requires_manual = contract.requires_manual_review
+        has_consumption_gap = False
+        has_fault_alert = False
+        telemetry_ok = True
+        has_recent_promise = False
+        has_delinquency = contract.status.lower() == "expired"
+
     return ProtectionContext(
-        market=market,
-        balance=profile.balance,
-        payment=profile.payment,
-        term_months=profile.term_months,
+        market=market_value,
+        balance=balance,
+        payment=payment,
+        term_months=term_months,
         restructures_used=0,
         restructures_allowed=None,
         plan_type=contract.plan_type,
-        protections_used=contract.protections_used,
-        protections_allowed=contract.protections_allowed,
-        contract_status=contract.status,
-        contract_valid_until=contract.valid_until,
-        contract_reset_cycle_days=contract.reset_cycle_days,
-        requires_manual_review=contract.requires_manual_review,
-        has_consumption_gap=False,
-        has_fault_alert=False,
-        has_delinquency_flag=contract.status.lower() == "expired",
-        has_recent_promise_break=False,
-        telematics_ok=True,
+        protections_used=protections_used,
+        protections_allowed=protections_allowed,
+        contract_status=status,
+        contract_valid_until=valid_until,
+        contract_reset_cycle_days=reset_cycle_days,
+        requires_manual_review=requires_manual,
+        has_consumption_gap=has_consumption_gap,
+        has_fault_alert=has_fault_alert,
+        has_delinquency_flag=has_delinquency,
+        has_recent_promise_break=has_recent_promise,
+        telematics_ok=telemetry_ok,
     )
 
 
-def log_outcome(context: ProtectionContext, contract: ProtectionContract, risk_band: str, notes: str, log_path: Path) -> Optional[dict]:
+def prepare_decision(
+    contract: ProtectionContract,
+    profile: FinancialProfile,
+    state: Optional[Dict[str, str]],
+) -> Tuple[PIADecision, Dict[str, Any]]:
+    expected_payment = profile.payment
+    payload: Dict[str, Any] = {
+        "placa": contract.placa,
+        "expected_payment": expected_payment,
+        "coverage_ratio_30d": 0.0,
+        "coverage_ratio_14d": 0.0,
+        "downtime_hours_30d": 0.0,
+        "bank_transfer": 0.0,
+        "gnv_credit_30d": 0.0,
+        "arrears_amount": 0.0,
+        "last_protection_at": None,
+        "protections_allowed": contract.protections_allowed,
+        "protections_used": contract.protections_used,
+    }
+
+    if state:
+        payload.update(
+            {
+                "expected_payment": _to_float(state.get("expected_payment"), expected_payment),
+                "coverage_ratio_30d": _to_float(state.get("coverage_ratio_30d"), 0.0),
+                "coverage_ratio_14d": _to_float(state.get("coverage_ratio_14d"), 0.0),
+                "downtime_hours_30d": _to_float(state.get("downtime_hours_30d"), 0.0),
+                "bank_transfer": _to_float(state.get("bank_transfer"), 0.0),
+                "gnv_credit_30d": _to_float(state.get("gnv_credit_30d"), 0.0),
+                "gnv_credit_14d": _to_float(state.get("gnv_credit_14d"), 0.0),
+                "gnv_credit_7d": _to_float(state.get("gnv_credit_7d"), 0.0),
+                "arrears_amount": _to_float(state.get("arrears_amount"), 0.0),
+                "distance_km_30d": _to_float(state.get("distance_km_30d"), 0.0),
+                "engine_hours_30d": _to_float(state.get("engine_hours_30d"), 0.0),
+                "fault_events_30d": _to_float(state.get("fault_events_30d"), 0.0),
+                "cash_collection": _to_float(state.get("cash_collection"), 0.0),
+                "observed_payment": _to_float(state.get("observed_payment"), 0.0),
+                "avg_30d_litros": _to_float(state.get("avg_30d_litros"), 0.0),
+                "last_protection_at": state.get("last_protection_at"),
+                "suggested_scenario": state.get("scenario"),
+                "hase_consumption_gap_flag": _to_int(state.get("hase_consumption_gap_flag"), 0),
+                "hase_fault_alert_flag": _to_int(state.get("hase_fault_alert_flag"), 0),
+                "hase_telemetry_ok_flag": _to_int(state.get("hase_telemetry_ok_flag"), 1),
+                "protections_allowed": _to_int(state.get("protections_allowed"), contract.protections_allowed),
+                "protections_used": _to_int(state.get("protections_used"), contract.protections_used),
+            }
+        )
+        scenario_label = (state.get("scenario") or "").strip().lower()
+        if scenario_label == "delinquency" and _to_int(state.get("has_recent_promise_break"), 0):
+            payload["intent"] = "payment_promise"
+        elif scenario_label == "baseline" and _to_float(state.get("arrears_amount"), 0.0) < 0:
+            payload["intent"] = "advance_payment"
+
+    hase_score = score_payload(payload)
+    payload["risk_score"] = hase_score.risk_score
+
+    decision = decide_action(payload)
+    decision.details.update(
+        {
+            "bank_transfer": payload.get("bank_transfer", 0.0),
+            "cash_collection": payload.get("cash_collection", 0.0),
+            "gnv_credit_30d": payload.get("gnv_credit_30d", 0.0),
+            "gnv_credit_14d": payload.get("gnv_credit_14d", 0.0),
+            "gnv_credit_7d": payload.get("gnv_credit_7d", 0.0),
+            "downtime_hours_30d": payload.get("downtime_hours_30d", 0.0),
+            "scenario_hint": payload.get("suggested_scenario"),
+        }
+    )
+    if state:
+        decision.details.setdefault("market", state.get("market"))
+    else:
+        decision.details.setdefault("market", "synthetic_lab")
+
+    metadata: Dict[str, Any] = {
+        "hase_score": hase_score.to_dict(),
+    }
+    if state:
+        metadata["synthetic_state"] = state
+    return decision, metadata
+
+
+def log_outcome(
+    context: ProtectionContext,
+    decision: PIADecision,
+    *,
+    plan_label: str,
+    notes: str,
+    log_path: Path,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[dict]:
     policy = get_default_policy()
-    decision = PIADecision(
-        placa=contract.placa,
-        risk_band=risk_band,
-        action="evaluate_protection",
-        reason="Evaluación sintética de protección",
-        scenario="synthetic_lab",
-        template="PIA_PROTECCION",
-        details={"market": context.market, "source": "pia_generate_dummy_outcomes"},
-    )
+    metadata_payload: Dict[str, Any] = {
+        "channel": "synthetic_lab",
+        "source": "pia_generate_dummy_outcomes",
+    }
+    if metadata:
+        metadata_payload.update(metadata)
     result = evaluate_scenarios(
         context,
         policy,
@@ -167,17 +337,17 @@ def log_outcome(context: ProtectionContext, contract: ProtectionContract, risk_b
         log_outcome=True,
         outcome_label="synthetic_protection",
         notes=notes,
-        metadata={"channel": "synthetic_lab", "source": "pia_generate_dummy_outcomes"},
+        metadata=metadata_payload,
     )
     viable = result.get("viable", [])
     if viable:
         top = viable[0]
         print(
-            f"[{contract.placa}] {contract.plan_type} → {top['type']} (manual={top.get('requires_manual_review', False)})",
+            f"[{decision.placa}] {plan_label} | {decision.action} → {top['type']} (manual={top.get('requires_manual_review', False)})",
             flush=True,
         )
         return top
-    print(f"[{contract.placa}] {contract.plan_type} → sin escenarios viables", flush=True)
+    print(f"[{decision.placa}] {plan_label} → sin escenarios viables", flush=True)
     return None
 
 
@@ -240,11 +410,23 @@ def main() -> int:
     if args.reset_log:
         maybe_reset_log(args.log)
 
+    states = load_states(args.states)
+
     total_viable = 0
     for index, contract in iterate_contracts(args.contracts):
         profile = select_financials(contract.plan_type, index)
-        context = build_context(contract, profile, args.market)
-        result = log_outcome(context, contract, args.risk_band, args.notes, args.log)
+        state = states.get(contract.placa.upper())
+        context = build_context(contract, profile, args.market, state)
+        decision, metadata = prepare_decision(contract, profile, state)
+        plan_label = context.plan_type or contract.plan_type or 'unknown'
+        result = log_outcome(
+            context,
+            decision,
+            plan_label=plan_label,
+            notes=args.notes,
+            log_path=args.log,
+            metadata=metadata,
+        )
         if result is not None:
             total_viable += 1
 

--- a/scripts/pia_plan_summary_monitor.py
+++ b/scripts/pia_plan_summary_monitor.py
@@ -36,8 +36,7 @@ def main(summary: Path = DEFAULT_SUMMARY, features: Path = DEFAULT_FEATURES) -> 
             print(f'Contratos {label}: {len(df)}')
             print(df[['placa', 'last_plan_type', 'last_plan_status', 'protections_remaining']].to_string(index=False))
 
-    print('
-=== Alertas ===')
+    print('\n=== Alertas ===')
     _report(negatives, 'con protecciones negativas')
     _report(expirados, 'con plan expirado')
     _report(manual, 'marcados para revisión manual')

--- a/scripts/pia_seed_synthetic_portfolio.py
+++ b/scripts/pia_seed_synthetic_portfolio.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Seed a synthetic driver portfolio grounded on historical HASE telemetry.
+
+The generator samples the latest records per placa from the HASE training dataset,
+perturbs them with realistic noise and assigns each driver a protection plan.
+
+Outputs
+-------
+- data/pia/synthetic_contracts.csv
+- data/pia/synthetic_driver_states.csv
+
+Both files are produced with ~200 financiamientos by default and can be fed into
+`pia_generate_dummy_outcomes.py` to simulate the full loop (HASE → PIA → TIR).
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import random
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = ROOT / "data"
+HASE_DATA_CANDIDATES: tuple[Path, ...] = (
+    DATA_DIR / "hase" / "hase_training_dataset_full.csv.gz",
+    DATA_DIR / "hase" / "hase_training_dataset.csv.gz",
+)
+
+CONTRACTS_OUT_DEFAULT = DATA_DIR / "pia" / "synthetic_contracts.csv"
+STATES_OUT_DEFAULT = DATA_DIR / "pia" / "synthetic_driver_states.csv"
+
+
+@dataclass(frozen=True)
+class PlanConfig:
+    name: str
+    balance: float
+    payment: float
+    term_months: int
+    protections_allowed: int
+    reset_cycle_days: int
+
+
+PLAN_CATALOG: Dict[str, PlanConfig] = {
+    "proteccion_total": PlanConfig("proteccion_total", 520_000, 19_000, 48, 3, 365),
+    "proteccion_basica": PlanConfig("proteccion_basica", 470_000, 16_800, 44, 2, 240),
+    "proteccion_light": PlanConfig("proteccion_light", 360_000, 13_500, 36, 1, 180),
+    "proteccion_caduca": PlanConfig("proteccion_caduca", 455_000, 17_200, 40, 2, 365),
+    "proteccion_ilimitada": PlanConfig("proteccion_ilimitada", 610_000, 20_500, 60, 4, 180),
+}
+
+PLAN_WEIGHTS: Dict[str, float] = {
+    "proteccion_total": 0.32,
+    "proteccion_basica": 0.26,
+    "proteccion_light": 0.18,
+    "proteccion_caduca": 0.14,
+    "proteccion_ilimitada": 0.10,
+}
+
+SCENARIO_WEIGHTS: Dict[str, float] = {
+    "baseline": 0.55,
+    "consumption_gap": 0.2,
+    "fault_alert": 0.15,
+    "delinquency": 0.1,
+}
+
+RNG = np.random.default_rng()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate synthetic driver metrics grounded on historical telemetry")
+    parser.add_argument("--size", type=int, default=200, help="Número de financiamientos a generar")
+    parser.add_argument("--seed", type=int, default=42, help="Semilla para reproducibilidad")
+    parser.add_argument(
+        "--contracts-out",
+        type=Path,
+        default=CONTRACTS_OUT_DEFAULT,
+        help="Ruta de salida para contratos sintéticos",
+    )
+    parser.add_argument(
+        "--states-out",
+        type=Path,
+        default=STATES_OUT_DEFAULT,
+        help="Ruta de salida para estados/telemetría sintética",
+    )
+    parser.add_argument(
+        "--hase-source",
+        type=Path,
+        default=None,
+        help="Ruta explícita al dataset histórico de HASE (CSV/CSV.GZ)",
+    )
+    return parser.parse_args()
+
+
+def load_hase_snapshot(path: Path | None) -> pd.DataFrame:
+    """Return the latest record per placa from the HASE training dataset."""
+
+    candidate_paths: Iterable[Path]
+    if path is not None:
+        candidate_paths = (path,)
+    else:
+        candidate_paths = HASE_DATA_CANDIDATES
+
+    for candidate in candidate_paths:
+        if candidate.exists():
+            df = pd.read_csv(candidate, parse_dates=["fecha_dia"], low_memory=False)
+            break
+    else:
+        raise FileNotFoundError(
+            "No pude encontrar un dataset histórico de HASE. Revisa data/hase/hase_training_dataset_full.csv.gz"
+        )
+
+    if "fecha_dia" not in df.columns:
+        df["fecha_dia"] = pd.Timestamp.today().normalize()
+
+    df = df.sort_values(["placa", "fecha_dia"]).drop_duplicates("placa", keep="last")
+    df = df.reset_index(drop=True)
+    return df
+
+
+def pick_plan(rng: np.random.Generator) -> PlanConfig:
+    plans, weights = zip(*PLAN_WEIGHTS.items())
+    choice = rng.choice(plans, p=weights)
+    return PLAN_CATALOG[str(choice)]
+
+
+def choose_scenario(rng: np.random.Generator) -> str:
+    scenarios, weights = zip(*SCENARIO_WEIGHTS.items())
+    return str(rng.choice(scenarios, p=weights))
+
+
+def _clip(value: float, lo: float, hi: float) -> float:
+    return float(min(max(value, lo), hi))
+
+
+def _clean(value: float | int | str | None, default: float = 0.0) -> float:
+    if value is None:
+        return float(default)
+    try:
+        val = float(value)
+        if math.isnan(val):
+            return float(default)
+        return val
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def synthesize_records(df: pd.DataFrame, size: int, seed: int) -> tuple[pd.DataFrame, pd.DataFrame]:
+#if size > len(df): sample with replacement.
+    rng = np.random.default_rng(seed)
+    sampled = df.sample(n=size, replace=len(df) < size, random_state=seed).reset_index(drop=True)
+
+    contracts: List[Dict[str, object]] = []
+    states: List[Dict[str, object]] = []
+
+    today = date.today()
+    base_valid_until = today.replace(day=28)
+
+    for idx, row in sampled.iterrows():
+        plan = pick_plan(rng)
+        scenario = choose_scenario(rng)
+
+        placa = f"LAB-{idx:03d}"
+        plaza = str(row.get("plaza_limpia", "EDOMEX")).strip() or "EDOMEX"
+
+        coverage30 = _clip(_clean(row.get("coverage_ratio_30d"), default=0.9), 0.1, 1.6)
+        coverage14 = _clip(_clean(row.get("coverage_ratio_14d"), default=coverage30 * 0.85), 0.05, 1.5)
+        coverage7 = _clip(_clean(row.get("coverage_ratio_7d"), default=coverage14 * 0.9), 0.02, 1.4)
+
+        downtime30 = _clip(_clean(row.get("downtime_hours_30d"), default=row.get("downtime_hours")), 0.0, 280.0)
+        downtime14 = _clip(_clean(row.get("downtime_hours_14d"), default=downtime30 * 0.45), 0.0, 160.0)
+        downtime7 = _clip(_clean(row.get("downtime_hours_7d"), default=downtime14 * 0.5), 0.0, 96.0)
+
+        litros30 = _clip(_clean(row.get("litros_30d"), 950.0), 200.0, 3800.0)
+        avg_30d_litros = litros30 / 30.0
+
+        expected_payment = plan.payment
+
+        # Payment channel composition.
+        if scenario == "delinquency":
+            transfer_ratio = rng.uniform(0.2, 0.45)
+        elif scenario == "consumption_gap":
+            transfer_ratio = rng.uniform(0.35, 0.55)
+        elif scenario == "fault_alert":
+            transfer_ratio = rng.uniform(0.4, 0.6)
+        else:
+            transfer_ratio = rng.uniform(0.45, 0.7)
+
+        bank_transfer = round(expected_payment * transfer_ratio, 2)
+        # Cash reflects total observed payment shortfall or surplus.
+        if scenario == "delinquency":
+            effective_ratio = rng.uniform(0.35, 0.85)
+        elif scenario == "consumption_gap":
+            effective_ratio = rng.uniform(0.75, 0.95)
+        elif scenario == "fault_alert":
+            effective_ratio = rng.uniform(0.8, 1.0)
+        else:
+            effective_ratio = rng.uniform(0.95, 1.08)
+
+        observed_payment = _clip(expected_payment * effective_ratio, 5000.0, expected_payment * 1.2)
+        cash_collection = max(observed_payment - bank_transfer, 0.0)
+
+        arrears_amount = round(max(0.0, expected_payment - observed_payment), 2)
+        if scenario == "baseline" and rng.random() < 0.12:
+            arrears_amount = round(-expected_payment * rng.uniform(0.05, 0.12), 2)  # prepago
+
+        gnv_credit_30d = round(expected_payment * coverage30 * rng.uniform(0.85, 1.1), 2)
+        gnv_credit_14d = round(expected_payment * coverage14, 2)
+        gnv_credit_7d = round(expected_payment * coverage7, 2)
+
+        distance_km_30d = round(litros30 * rng.uniform(2.6, 3.4), 1)
+        engine_hours_30d = round(distance_km_30d / rng.uniform(25.0, 32.0), 1)
+        fault_events_30d = 0
+        if scenario == "fault_alert":
+            fault_events_30d = rng.integers(2, 6)
+        elif downtime30 > 180:
+            fault_events_30d = rng.integers(1, 3)
+
+        hase_consumption_gap_flag = int(scenario == "consumption_gap")
+        hase_fault_alert_flag = int(scenario == "fault_alert")
+        hase_telemetry_ok_flag = int(downtime14 < 120)
+
+        protections_allowed = plan.protections_allowed
+        protections_used = int(rng.integers(0, protections_allowed + 1))
+        protections_remaining = protections_allowed - protections_used
+        if scenario == "delinquency" and protections_remaining <= 0:
+            protections_remaining -= rng.integers(1, 2)
+        if scenario == "fault_alert" and protections_remaining == protections_allowed:
+            protections_used = max(1, protections_used)
+            protections_remaining = protections_allowed - protections_used
+
+        status = "active"
+        requires_manual_review = False
+        if scenario == "delinquency" and rng.random() < 0.55:
+            status = "expired"
+            requires_manual_review = True
+        elif scenario == "fault_alert" and rng.random() < 0.25:
+            requires_manual_review = True
+        elif protections_remaining < 0:
+            requires_manual_review = True
+
+        has_recent_promise_break = bool(scenario == "delinquency" and rng.random() < 0.6)
+
+        days_offset = int(rng.uniform(18, 120))
+        last_protection_at = (today - timedelta(days=days_offset)).isoformat()
+
+        contract = {
+            "placa": placa,
+            "plan_type": plan.name,
+            "protections_allowed": protections_allowed,
+            "protections_used": protections_used,
+            "status": status,
+            "valid_until": (base_valid_until + timedelta(days=int(rng.integers(45, 220)))).isoformat(),
+            "reset_cycle_days": plan.reset_cycle_days,
+            "requires_manual_review": "yes" if requires_manual_review else "no",
+        }
+        contracts.append(contract)
+
+        state = {
+            "placa": placa,
+            "market": plaza,
+            "plan_type": plan.name,
+            "balance": plan.balance,
+            "payment": plan.payment,
+            "term_months": plan.term_months,
+            "protections_allowed": protections_allowed,
+            "protections_used": protections_used,
+            "protections_remaining": protections_remaining,
+            "contract_status": status,
+            "contract_valid_until": contract["valid_until"],
+            "contract_reset_cycle_days": plan.reset_cycle_days,
+            "requires_manual_review": requires_manual_review,
+            "expected_payment": expected_payment,
+            "bank_transfer": round(bank_transfer, 2),
+            "cash_collection": round(cash_collection, 2),
+            "observed_payment": round(observed_payment, 2),
+            "arrears_amount": arrears_amount,
+            "coverage_ratio_30d": round(coverage30, 3),
+            "coverage_ratio_14d": round(coverage14, 3),
+            "coverage_ratio_7d": round(coverage7, 3),
+            "gnv_credit_30d": gnv_credit_30d,
+            "gnv_credit_14d": gnv_credit_14d,
+            "gnv_credit_7d": gnv_credit_7d,
+            "litros_30d": round(litros30, 2),
+            "avg_30d_litros": round(avg_30d_litros, 2),
+            "downtime_hours_30d": round(downtime30, 2),
+            "downtime_hours_14d": round(downtime14, 2),
+            "downtime_hours_7d": round(downtime7, 2),
+            "distance_km_30d": round(distance_km_30d, 1),
+            "engine_hours_30d": round(engine_hours_30d, 1),
+            "fault_events_30d": int(fault_events_30d),
+            "hase_consumption_gap_flag": hase_consumption_gap_flag,
+            "hase_fault_alert_flag": hase_fault_alert_flag,
+            "hase_telemetry_ok_flag": hase_telemetry_ok_flag,
+            "has_recent_promise_break": int(has_recent_promise_break),
+            "last_protection_at": last_protection_at,
+            "scenario": scenario,
+            "risk_story": (
+                "proteccion_negativa"
+                if protections_remaining < 0
+                else ("promesa_incumplida" if has_recent_promise_break else scenario)
+            ),
+        }
+        states.append(state)
+
+    return pd.DataFrame(contracts), pd.DataFrame(states)
+
+
+def main() -> int:
+    args = parse_args()
+    global RNG
+    RNG = np.random.default_rng(args.seed)
+
+    df = load_hase_snapshot(args.hase_source)
+
+    contracts_df, states_df = synthesize_records(df, args.size, args.seed)
+
+    args.contracts_out.parent.mkdir(parents=True, exist_ok=True)
+    args.states_out.parent.mkdir(parents=True, exist_ok=True)
+
+    contracts_df.to_csv(args.contracts_out, index=False)
+    states_df.to_csv(args.states_out, index=False)
+
+    print(
+        f"Generados {len(states_df)} contratos sintéticos → {args.contracts_out.relative_to(ROOT)} / {args.states_out.relative_to(ROOT)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Implement synthetic protection demo pipeline with PIA/HASE/TIR integration
- Add demo scripts for portfolio seeding and dummy outcome generation  
- Extend HASE service with protection scoring capabilities
- Add comprehensive documentation for dashboard and demo runbook

## Changes
- **Scripts**: `demo_proteccion.py`, `pia_seed_synthetic_portfolio.py`, `pia_generate_dummy_outcomes.py`, `pia_plan_summary_monitor.py`
- **Agents**: Enhanced `agents/hase/src/service.py` with protection logic
- **Tests**: Updated `agents/hase/tests/test_hase_service.py` 
- **Makefile**: Added `demo-proteccion` target
- **Docs**: Added `demo_runbook_hase_pia_tir_proteccion.md` and `hus_dashboard_proteccion.md`

## Test plan
- [ ] Run `make demo-proteccion` to verify pipeline execution
- [ ] Test synthetic portfolio generation with `pia_seed_synthetic_portfolio.py`
- [ ] Validate HASE protection scoring functionality
- [ ] Review dashboard documentation for completeness

🤖 Generated with [Claude Code](https://claude.ai/code)