### PR TITLE
Wire PIA agent to HASE stub

### DIFF
--- a/agents/hase/src/__init__.py
+++ b/agents/hase/src/__init__.py
@@ -1,1 +1,3 @@
 """HASE synthetic and training utilities package."""
+
+from .service import HaseScore, score_driver, score_payload  # noqa: F401

--- a/agents/pia/tests/test_pia_agent_chain.py
+++ b/agents/pia/tests/test_pia_agent_chain.py
@@ -11,6 +11,26 @@ def test_build_pia_agent_exposes_tools():
     assert {"consult_hase", "simulate_pia", "trigger_make_webhook"}.issubset(tool_names)
 
 
+def test_consult_hase_tool_uses_stub_scoring():
+    agent = build_pia_agent()
+    payload = {
+        "placa": "LAB-002",
+        "coverage_ratio_14d": 0.52,
+        "coverage_ratio_30d": 0.58,
+        "downtime_hours_30d": 80,
+        "expected_payment": 11000,
+        "bank_transfer": 3000,
+        "gnv_credit_30d": 4200,
+        "arrears_amount": 2800,
+    }
+    consult = next(tool for tool in agent.tools if tool.name == "consult_hase")
+    result = consult.func(payload)
+
+    assert result["placa"] == "LAB-002"
+    assert 0.0 <= result["risk_score"] <= 1.0
+    assert 0.0 <= result["probability_default"] <= 1.0
+
+
 def test_pia_agent_simulate_decision_dict():
     agent: PIAgent = build_pia_agent()
     result = agent.simulate(

--- a/app/schemas/protection.py
+++ b/app/schemas/protection.py
@@ -38,7 +38,7 @@ class ProtectionEvaluateRequest(BaseModel):
     has_recent_promise_break: bool = False
     telematics_ok: bool = True
 
-    log_outcome: bool = False
+    log_outcome: bool = True
     decision_action: Optional[str] = Field(None, description="Original PIA decision action")
     decision_reason: Optional[str] = None
     decision_placa: Optional[str] = Field(None, description="Placa asociada para logging opcional")


### PR DESCRIPTION
## Summary
- Wire PIA agent to use real HASE stub instead of mocks
- Export HASE scoring functionality for PIA integration
- Add automatic outcome logging for protection evaluations
- Validate HASE score responses in PIA agent tests

## Changes
- **HASE exports**: `agents/hase/src/__init__.py` now exports `HaseScore`, `score_payload`, `score_driver`
- **PIA integration**: `agents/pia/src/chain.py` removes mocks and uses real HASE stub via `PIAgent.consult_hase` helper
- **Test validation**: `agents/pia/tests/test_pia_agent_chain.py` validates that `consult_hase` returns valid scores
- **Auto-logging**: `app/schemas/protection.py` enables `log_outcome=True` to automatically register each evaluation

## Test plan
- [ ] Run PIA agent tests to verify HASE integration works
- [ ] Test `consult_hase` method returns valid score responses
- [ ] Verify automatic outcome logging is enabled
- [ ] Validate HASE stub functionality with real PIA scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)